### PR TITLE
Corrections to various accents

### DIFF
--- a/sblgnt/01-matthew.xml
+++ b/sblgnt/01-matthew.xml
@@ -20831,7 +20831,7 @@
      <token id="SBL.Matt.26.36.7" clearId="n40026036007">εἰς</token>
      <token id="SBL.Matt.26.36.8" clearId="n40026036008">χωρίον</token>
      <token id="SBL.Matt.26.36.9" clearId="n40026036009">λεγόμενον</token>
-     <token id="SBL.Matt.26.36.10" clearId="n40026036010" after=",">Γεθσημανὶ</token>
+     <token id="SBL.Matt.26.36.10" clearId="n40026036010" after=",">Γεθσημανί</token>
      <token id="SBL.Matt.26.36.11" clearId="n40026036011">καὶ</token>
      <token id="SBL.Matt.26.36.12" clearId="n40026036012">λέγει</token>
      <token id="SBL.Matt.26.36.13" clearId="n40026036013">τοῖς</token>

--- a/sblgnt/01-matthew.xml
+++ b/sblgnt/01-matthew.xml
@@ -11144,7 +11144,7 @@
       <move id="m.SBL.Matt.15.14.3-6" chStart="15" vStart="14" chEnd="15" vEnd="14">
        <token id="SBL.Matt.15.14.3" clearId="n40015014003">τυφλοί</token>
        <token id="SBL.Matt.15.14.4" clearId="n40015014004">εἰσιν</token>
-       <token id="SBL.Matt.15.14.5" clearId="n40015014005">ὁδηγοί</token>
+       <token id="SBL.Matt.15.14.5" clearId="n40015014005">ὁδηγοὶ</token>
        <token id="SBL.Matt.15.14.6" clearId="n40015014006" after="·">τυφλῶν</token>
       </move>
       <move id="m.SBL.Matt.15.14.7-15" chStart="15" vStart="14" chEnd="15" vEnd="14">

--- a/sblgnt/01-matthew.xml
+++ b/sblgnt/01-matthew.xml
@@ -11170,7 +11170,7 @@
      <token id="SBL.Matt.15.15.7" clearId="n40015015007">Φράσον</token>
      <token id="SBL.Matt.15.15.8" clearId="n40015015008">ἡμῖν</token>
      <token id="SBL.Matt.15.15.9" clearId="n40015015009">τὴν</token>
-     <token id="SBL.Matt.15.15.10" clearId="n40015015010">παραβολήν</token>
+     <token id="SBL.Matt.15.15.10" clearId="n40015015010">παραβολὴν</token>
      <token id="SBL.Matt.15.15.11" clearId="n40015015011" after=".">ταύτην</token>
     </move>
     <move id="m.SBL.Matt.15.16-20" chStart="15" vStart="16" chEnd="15" vEnd="20">

--- a/sblgnt/02-mark.xml
+++ b/sblgnt/02-mark.xml
@@ -5843,7 +5843,7 @@
       </move>
       <move id="m.SBL.Mark.7.27.9-21" chStart="7" vStart="27" chEnd="7" vEnd="27">
        <token id="SBL.Mark.7.27.9" clearId="n41007027009">οὐ</token>
-       <token id="SBL.Mark.7.27.10" clearId="n41007027010">γάρ</token>
+       <token id="SBL.Mark.7.27.10" clearId="n41007027010">γὰρ</token>
        <token id="SBL.Mark.7.27.11" clearId="n41007027011">καλόν</token>
        <token id="SBL.Mark.7.27.12" clearId="n41007027012">ἐστιν</token>
        <token id="SBL.Mark.7.27.13" clearId="n41007027013">λαβεῖν</token>

--- a/sblgnt/03-luke.xml
+++ b/sblgnt/03-luke.xml
@@ -566,7 +566,7 @@
      <token id="SBL.Luke.1.27.7" clearId="n42001027007">Ἰωσὴφ</token>
      <token id="SBL.Luke.1.27.8" clearId="n42001027008">ἐξ</token>
      <token id="SBL.Luke.1.27.9" clearId="n42001027009">οἴκου</token>
-     <token id="SBL.Luke.1.27.10" clearId="n42001027010" after=",">Δαυὶδ</token>
+     <token id="SBL.Luke.1.27.10" clearId="n42001027010" after=",">Δαυίδ</token>
     </move>
     <move id="m.SBL.Luke.1.27.11-16" chStart="1" vStart="27" chEnd="1" vEnd="27">
      <token id="SBL.Luke.1.27.11" clearId="n42001027011">καὶ</token>

--- a/sblgnt/03-luke.xml
+++ b/sblgnt/03-luke.xml
@@ -4187,7 +4187,7 @@
      <token id="SBL.Luke.5.1.19" clearId="n42005001019">παρὰ</token>
      <token id="SBL.Luke.5.1.20" clearId="n42005001020">τὴν</token>
      <token id="SBL.Luke.5.1.21" clearId="n42005001021">λίμνην</token>
-     <token id="SBL.Luke.5.1.22" clearId="n42005001022" after=",">Γεννησαρὲτ</token>
+     <token id="SBL.Luke.5.1.22" clearId="n42005001022" after=",">Γεννησαρέτ</token>
     </move>
     <move id="m.SBL.Luke.5.2.1-8" chStart="5" vStart="2" chEnd="5" vEnd="2">
      <token id="SBL.Luke.5.2.1" clearId="n42005002001">καὶ</token>

--- a/sblgnt/03-luke.xml
+++ b/sblgnt/03-luke.xml
@@ -2435,7 +2435,7 @@
      <token id="SBL.Luke.2.51.5" clearId="n42002051005">καὶ</token>
      <token id="SBL.Luke.2.51.6" clearId="n42002051006">ἦλθεν</token>
      <token id="SBL.Luke.2.51.7" clearId="n42002051007">εἰς</token>
-     <token id="SBL.Luke.2.51.8" clearId="n42002051008" after=",">Ναζαρὲθ</token>
+     <token id="SBL.Luke.2.51.8" clearId="n42002051008" after=",">Ναζαρέθ</token>
     </move>
     <move id="m.SBL.Luke.2.51.9-12" chStart="2" vStart="51" chEnd="2" vEnd="51">
      <token id="SBL.Luke.2.51.9" clearId="n42002051009">καὶ</token>

--- a/sblgnt/03-luke.xml
+++ b/sblgnt/03-luke.xml
@@ -7962,7 +7962,7 @@
      <token id="SBL.Luke.8.20.12" clearId="n42008020012">ἔξω</token>
      <token id="SBL.Luke.8.20.13" clearId="n42008020013">ἰδεῖν</token>
      <token id="SBL.Luke.8.20.14" clearId="n42008020014">σε</token>
-     <token id="SBL.Luke.8.20.15" clearId="n42008020015" after=".">θέλοντές</token>
+     <token id="SBL.Luke.8.20.15" clearId="n42008020015" after=".">θέλοντες</token>
     </move>
     <move id="m.SBL.Luke.8.21" chStart="8" vStart="21" chEnd="8" vEnd="21">
      <token id="SBL.Luke.8.21.1" clearId="n42008021001">ὁ</token>

--- a/sblgnt/04-john.xml
+++ b/sblgnt/04-john.xml
@@ -6970,7 +6970,7 @@
        <token id="SBL.John.7.34.2" clearId="n43007034002">με</token>
        <token id="SBL.John.7.34.3" clearId="n43007034003">καὶ</token>
        <token id="SBL.John.7.34.4" clearId="n43007034004">οὐχ</token>
-       <token id="SBL.John.7.34.5" clearId="n43007034005" after=",">εὑρήσετέ</token>
+       <token id="SBL.John.7.34.5" clearId="n43007034005" after=",">εὑρήσετε</token>
        <token id="SBL.John.7.34.6" clearId="n43007034006">καὶ</token>
        <token id="SBL.John.7.34.7" clearId="n43007034007">ὅπου</token>
        <token id="SBL.John.7.34.8" clearId="n43007034008">εἰμὶ</token>
@@ -7027,7 +7027,7 @@
        <token id="SBL.John.7.36.9" clearId="n43007036009">με</token>
        <token id="SBL.John.7.36.10" clearId="n43007036010">καὶ</token>
        <token id="SBL.John.7.36.11" clearId="n43007036011">οὐχ</token>
-       <token id="SBL.John.7.36.12" clearId="n43007036012" after=",">εὑρήσετέ</token>
+       <token id="SBL.John.7.36.12" clearId="n43007036012" after=",">εὑρήσετε</token>
        <token id="SBL.John.7.36.13" clearId="n43007036013">καὶ</token>
        <token id="SBL.John.7.36.14" clearId="n43007036014">ὅπου</token>
        <token id="SBL.John.7.36.15" clearId="n43007036015">εἰμὶ</token>

--- a/sblgnt/04-john.xml
+++ b/sblgnt/04-john.xml
@@ -10340,7 +10340,7 @@
      <token id="SBL.John.10.29.6" clearId="n43010029006">μοι</token>
      <token id="SBL.John.10.29.7" clearId="n43010029007">πάντων</token>
      <token id="SBL.John.10.29.8" clearId="n43010029008">μεῖζων</token>
-     <token id="SBL.John.10.29.9" clearId="n43010029009" after=",">ἐστιν</token>
+     <token id="SBL.John.10.29.9" clearId="n43010029009" after=",">ἐστίν</token>
      <token id="SBL.John.10.29.10" clearId="n43010029010">καὶ</token>
      <token id="SBL.John.10.29.11" clearId="n43010029011">οὐδεὶς</token>
      <token id="SBL.John.10.29.12" clearId="n43010029012">δύναται</token>

--- a/sblgnt/04-john.xml
+++ b/sblgnt/04-john.xml
@@ -7169,7 +7169,7 @@
        <token id="SBL.John.7.42.6" clearId="n43007042006">ἐκ</token>
        <token id="SBL.John.7.42.7" clearId="n43007042007">τοῦ</token>
        <token id="SBL.John.7.42.8" clearId="n43007042008">σπέρματος</token>
-       <token id="SBL.John.7.42.9" clearId="n43007042009" after=",">Δαυὶδ</token>
+       <token id="SBL.John.7.42.9" clearId="n43007042009" after=",">Δαυίδ</token>
        <token id="SBL.John.7.42.10" clearId="n43007042010">καὶ</token>
        <token id="SBL.John.7.42.11" clearId="n43007042011">ἀπὸ</token>
        <token id="SBL.John.7.42.12" clearId="n43007042012">Βηθλέεμ</token>
@@ -7177,7 +7177,7 @@
        <token id="SBL.John.7.42.14" clearId="n43007042014">κώμης</token>
        <token id="SBL.John.7.42.15" clearId="n43007042015">ὅπου</token>
        <token id="SBL.John.7.42.16" clearId="n43007042016">ἦν</token>
-       <token id="SBL.John.7.42.17" clearId="n43007042017" after=",">Δαυὶδ</token>
+       <token id="SBL.John.7.42.17" clearId="n43007042017" after=",">Δαυίδ</token>
        <token id="SBL.John.7.42.18" clearId="n43007042018">ἔρχεται</token>
        <token id="SBL.John.7.42.19" clearId="n43007042019">ὁ</token>
        <token id="SBL.John.7.42.20" clearId="n43007042020" after=";">χριστός</token>

--- a/sblgnt/05-acts.xml
+++ b/sblgnt/05-acts.xml
@@ -1187,7 +1187,7 @@
        <token id="SBL.Acts.2.29.9" clearId="n44002029009">περὶ</token>
        <token id="SBL.Acts.2.29.10" clearId="n44002029010">τοῦ</token>
        <token id="SBL.Acts.2.29.11" clearId="n44002029011">πατριάρχου</token>
-       <token id="SBL.Acts.2.29.12" clearId="n44002029012" after=",">Δαυὶδ</token>
+       <token id="SBL.Acts.2.29.12" clearId="n44002029012" after=",">Δαυίδ</token>
        <token id="SBL.Acts.2.29.13" clearId="n44002029013">ὅτι</token>
        <token id="SBL.Acts.2.29.14" clearId="n44002029014">καὶ</token>
        <token id="SBL.Acts.2.29.15" clearId="n44002029015">ἐτελεύτησεν</token>

--- a/sblgnt/22-2peter.xml
+++ b/sblgnt/22-2peter.xml
@@ -646,7 +646,7 @@
      <token id="SBL.2Pet.2.8.17" clearId="n61002008017" after="—">ἐβασάνιζεν</token>
     </move>
     <move id="m.SBL.2Pet.2.10.13-11.13" chStart="2" vStart="10" chEnd="2" vEnd="11">
-     <token id="SBL.2Pet.2.10.13" clearId="n61002010013" after=",">Τολμηταὶ</token>
+     <token id="SBL.2Pet.2.10.13" clearId="n61002010013" after=",">Τολμηταί</token>
      <token id="SBL.2Pet.2.10.14" clearId="n61002010014" after=",">αὐθάδεις</token>
      <token id="SBL.2Pet.2.10.15" clearId="n61002010015">δόξας</token>
      <token id="SBL.2Pet.2.10.16" clearId="n61002010016">οὐ</token>


### PR DESCRIPTION
I happened to do some cross-checking between this data source the text at https://github.com/LogosBible/SBLGNT/data/sblgnt/text, and found a number of discrepancies in the accents. The majority of them seem to be related to rules pertaining to [Changing Oxyone accents to grave](https://en.wikipedia.org/wiki/Ancient_Greek_accent).

In each case I've attempted to combine the rule, as well as the SBLGNT textual notes (when available), and accents of similar verses in other texts (namely those available from esv.org and greekbible.com).

Thanks for making this available, and I hope this helps.